### PR TITLE
Adds logging by default, other mods to allow use with litellm

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,7 @@ authors = [
   { name="Emery Berger", email="emery.berger@gmail.com" },
   { name="Sam Stern", email="sternj@umass.edu" }
 ]
-dependencies = ["tiktoken>=0.5.1", "openai>=1.11.0", "botocore>=1.34.34", "botocore-types>=0.2.2", "types-requests>=2.31.0.20240125"]
+dependencies = ["tiktoken>=0.5.2", "openai>=1.11.0", "botocore>=1.34.34", "botocore-types>=0.2.2", "types-requests>=2.31.0.20240125"]
 description = "Utilities for our LLM projects (CWhy, ChatDBG, ...)."
 readme = "README.md"
 requires-python = ">=3.9"

--- a/src/llm_utils/chat.py
+++ b/src/llm_utils/chat.py
@@ -25,7 +25,6 @@ from llm_utils.utils import contains_valid_json, extract_code_blocks
 
 log = logging.getLogger("rich")
 
-
 class ChatAPI(abc.ABC, Generic[T]):
     prompt_tokens: int
     completion_tokens: int
@@ -166,7 +165,7 @@ class Claude(ChatAPI[ClaudeMessageParam]):
         payload = cls.create_payload(conversation)
         for _ in range(5):
             inference = cls.get_inference(payload)
-            print("INFERENCE", inference["completion"])
+            log.info(f'Result: {inference["completion"]}')
 
             jsonified_completion = contains_valid_json(inference["completion"])
             if jsonified_completion is not None:

--- a/src/llm_utils/chat.py
+++ b/src/llm_utils/chat.py
@@ -24,6 +24,7 @@ T = TypeVar("T")
 from llm_utils.utils import contains_valid_json, extract_code_blocks
 
 log = logging.getLogger("rich")
+logging.basicConfig(filename='llm_utils.log', encoding='utf-8', level=logging.DEBUG)
 
 class ChatAPI(abc.ABC, Generic[T]):
     prompt_tokens: int
@@ -116,8 +117,8 @@ class Claude(ChatAPI[ClaudeMessageParam]):
     MODEL_ID: str = "anthropic.claude-v2"
     SERVICE_NAME: str = "bedrock"
     MAX_RETRY: int = 5
-    prompt_tokens: int = 0
-    completion_tokens: int = 0
+    prompt_tokens: int = 0      # FIXME not yet implemented
+    completion_tokens: int = 0  # ibid
 
     @classmethod
     def generate_chatlog(cls, conversations: List[ClaudeMessageParam]) -> str:
@@ -163,7 +164,7 @@ class Claude(ChatAPI[ClaudeMessageParam]):
             first_msg.rstrip() + "\n" + conversation[0]["content"]
         )
         payload = cls.create_payload(conversation)
-        for _ in range(5):
+        for _ in range(cls.MAX_RETRY):
             inference = cls.get_inference(payload)
             log.info(f'Result: {inference["completion"]}')
 

--- a/src/llm_utils/utils.py
+++ b/src/llm_utils/utils.py
@@ -7,9 +7,17 @@ from typing import Any, Dict, List, Optional
 # OpenAI specific.
 def count_tokens(model: str, string: str) -> int:
     """Returns the number of tokens in a text string."""
-    encoding = tiktoken.encoding_for_model(model)
-    num_tokens = len(encoding.encode(string))
-    return num_tokens
+    def extract_after_slash(s):
+      # Split the string by '/' and return the part after it if '/' is found, else return the whole string
+      parts = s.split('/', 1) # The '1' ensures we split at the first '/' only
+      return parts[1] if len(parts) > 1 else s
+
+    try:
+        encoding = tiktoken.encoding_for_model(extract_after_slash(model))
+        num_tokens = len(encoding.encode(string))
+        return num_tokens
+    except KeyError:
+        return 0
 
 
 # OpenAI specific.

--- a/src/llm_utils/utils.py
+++ b/src/llm_utils/utils.py
@@ -7,7 +7,7 @@ from typing import Any, Dict, List, Optional
 # OpenAI specific.
 def count_tokens(model: str, string: str) -> int:
     """Returns the number of tokens in a text string."""
-    def extract_after_slash(s):
+    def extract_after_slash(s: str) -> str:
       # Split the string by '/' and return the part after it if '/' is found, else return the whole string
       parts = s.split('/', 1) # The '1' ensures we split at the first '/' only
       return parts[1] if len(parts) > 1 else s


### PR DESCRIPTION
Incorporates mods to enable use with litellm and other providers.

Logging is now on by default. Clients downstream will likely want to use this to adjust the logging level so it only reports errors (or warnings).

```
# Turn off most logging                                                                                     
from llm_utils import logging
logging.getLogger().setLevel(logging.ERROR)
```